### PR TITLE
[Bug/#49] 칭찬100회 시 칭찬레벨뷰가 보이지 않는 버그 수정

### DIFF
--- a/Whale-iOS/Whale-iOS/Global/Model/LevelData.swift
+++ b/Whale-iOS/Whale-iOS/Global/Model/LevelData.swift
@@ -10,5 +10,6 @@ import Foundation
 // MARK: - LevelData
 struct LevelData: Codable {
     let nickName, whaleName: String
-    let userLevel, praiseCount, levelUpNeedCount: Int
+    let userLevel, praiseCount: Int
+    let levelUpNeedCount: Int?
 }

--- a/Whale-iOS/Whale-iOS/Screens/LevelTab/VC/LevelVC.swift
+++ b/Whale-iOS/Whale-iOS/Screens/LevelTab/VC/LevelVC.swift
@@ -382,7 +382,7 @@ extension LevelVC {
                     whaleName = whaleLevelData.whaleName
                     praiseCnt = CGFloat(whaleLevelData.praiseCount)
                     userLevel = CGFloat(whaleLevelData.userLevel)
-                    levelUpNeedCount = whaleLevelData.levelUpNeedCount
+                    levelUpNeedCount = whaleLevelData.levelUpNeedCount ?? 0
                     makeTopView(level: userLevel, praiseCnt: praiseCnt)
                     UserDefaults.standard.set(userLevel, forKey: "beforelevel")
                 }


### PR DESCRIPTION
### ⚠️  PR check list ⚠️
```
- commit message가 적절한지 확인해주세요. 
- 마지막으로 Coding Convention을 준수했는지 확인해주세요.
- 적절한 branch로 요청했는지 확인해주세요.
- Assignees, Label을 붙여주세요.
- 가능한 이슈를 Link 해주세요.
- PR이 승인된 경우 해당 브랜치는 삭제 부탁드립니다.
```

## 🌈 PR 요약
- 레벨 5 (레벨업이 MAX가 된 상태)에서는 레벨업에 남은 count가 없어서 levelUpNeedCount가 넘어오지 않아서 서버 통신이 안되는 상황이었음. 
- 따라서 LevelData모델에서 넘어올 수도, 안넘어올 수도 있는 levelUpNeedCount변수를 Optional로 선언해주어 문제를 해결했습니다!!!

## 📌 변경 사항
LevelData 모델 변경

#### Linked Issue
closed #49 
